### PR TITLE
Two factor client fix for non-breaking-space (0xa0)

### DIFF
--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -264,7 +264,7 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
     end
 
     def match_phone_to_masked_phone(phone_number, masked_number)
-      characters_to_remove_from_phone_numbers = ' \-()"'
+      characters_to_remove_from_phone_numbers = '  \-()"'
 
       # start with e.g. +49 162 1234585 or +1-123-456-7866
       phone_number = phone_number.tr(characters_to_remove_from_phone_numbers, '')


### PR DESCRIPTION
Added the non-breaking space character (0xa0) to the characters to be removed from the phone number in the match_phone_to_masked_phone function.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

It can happen that the phone number returned by Apple contains NBSP characters. When it does, the step of selecting the phone number automatically from the `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` env var fails with this message:

```
[!] The request could not be completed because:
	
Could not find a matching phone number to ...
```

This issue is very weird, we have several different Apple accounts, most of which don't have this issue. This problem only happens on a single specific Apple account, and it doesn't even happen consistently.

When I got stuck with the problem on my machine, I did some debugging by modifying my Fastlane installation files manually and found the source of the problem like this.

This is the output of printing the `phone_number` and `masked_number` when entering the `match_phone_to_masked_phone` function...

With a "normal" Apple account (not having this issue):

<img width="244" alt="image" src="https://github.com/user-attachments/assets/8978155f-5aa7-4933-8fe6-e943ac294ddc">

With an "affected" Apple account (having the issue):

<img width="315" alt="image" src="https://github.com/user-attachments/assets/61caeeaf-1603-45bb-9c14-b5742ea99bf4">

I did try setting those env vars, but it didn't help:

```
export LC_ALL=en_US.UTF-8
export LANG=en_US.UTF-8
```

### Description

The change simply adds the NBSP character to the list of characters to be removed from the phone number, so that when Apple somehow sends you the NBSP character with your phone number, the 2FA will still work.

### Testing Steps

I've tested this locally on my machine and it fixed the problem for me. Unfortunately it is impossible for me to provide reproduction steps since the issue is random and specific to my Apple account. Things work perfectly fine on other Apple accounts. I don't know what triggers this, but I'm thinking other Apple accounts could encounter this too.
